### PR TITLE
workaround webdav umlaut problems with mac os mavericks

### DIFF
--- a/lib/DAV/handler.js
+++ b/lib/DAV/handler.js
@@ -187,7 +187,7 @@ jsDAV_Handler.STATUS_MAP     = {
         // RFC5397
         "{DAV:}current-user-principal"
     ];
-    
+
     /**
      * This property allows you to automatically add the 'resourcetype' value
      * based on a node's classname or interface.
@@ -334,7 +334,7 @@ jsDAV_Handler.STATUS_MAP     = {
             cbgetnodefp(null, node);
         });
     };
-    
+
     /**
      * This method is called with every tree update
      *
@@ -858,7 +858,7 @@ jsDAV_Handler.STATUS_MAP     = {
     this.httpPut = function() {
         var self = this;
         var uri  = this.getRequestUri();
-        
+
         // Intercepting Content-Range
         if (this.httpRequest.headers["content-range"]) {
             /*
@@ -1240,7 +1240,7 @@ jsDAV_Handler.STATUS_MAP     = {
         var ctype;
         var self = this;
         var req = this.httpRequest;
-        var isStream = forceStream === true 
+        var isStream = forceStream === true
             ? true
             : (!(ctype = req.headers["content-type"]) || !ctype.match(/(urlencoded|multipart)/i));
 
@@ -1435,7 +1435,7 @@ jsDAV_Handler.STATUS_MAP     = {
                         for (var i = 0, l = ifMatch.length; i < l; ++i) {
                             // Stripping any extra spaces
                             ifMatchItem = Util.trim(ifMatch[i], " ");
-        
+
                             if (etag === ifMatchItem) {
                                 haveMatch = true;
                                 break;
@@ -1760,8 +1760,8 @@ jsDAV_Handler.STATUS_MAP     = {
                         "{DAV:}getcontenttype"
                     ];
                 }
-                
-                
+
+
                 // If the resourceType was not part of the list, we manually add it
                 // and mark it for removal. We need to know the resourcetype in order
                 // to make certain decisions about the entry.
@@ -1806,6 +1806,12 @@ jsDAV_Handler.STATUS_MAP     = {
                         if (removeRT)
                             delete newProps["200"]["{DAV:}resourcetype"];
 
+                        // 2013-11-14: Mac OS Mavericks GUI-Tools replace umlauts with composed ones,
+                        // WebDAVFS dosn't. In the end GUI-Tools can't files in paths containing umlauts
+                        if (self.httpRequest.headers['user-agent'].match('WebDAVFS/3.0')) {
+                            newProps["href"] = unorm.nfd(newProps["href"]);
+                        }
+
                         returnPropertyList[rpath] = newProps;
                         cbnext();
                     });
@@ -1820,7 +1826,7 @@ jsDAV_Handler.STATUS_MAP     = {
                             "403" : {},
                             "404" : {}
                         };
-                         
+
                         var myProperties = [].concat(propertyNames);
 
                         var propertyMap = Util.arrayToMap(myProperties);
@@ -2404,7 +2410,7 @@ jsDAV_Handler.STATUS_MAP     = {
                                     });
                                 });
                             }
-                            
+
                             function onDone() {
                                 self.markDirty(parentUri);
                                 self.dispatchEvent("afterBind", uri, Path.join(parent.path, newName));


### PR DESCRIPTION
Mac OS Mavericks can mount and browse Webdav-Directories without problems, even if the path contains umlauts. 
But you're not able to open any file within a path that contains any umlaut. 

Situation (afaik):
- Mavericks can browse Webdav with NFC-notated UTF-8
- Mavericks is unable to open (`open /Volume/<dav-mount>/<path>`) any file where the path contains a umlaut.

Solution: transform every path to UTF-8 NFD-notation. 
